### PR TITLE
Menu position

### DIFF
--- a/src/Entry/Entries.php
+++ b/src/Entry/Entries.php
@@ -34,6 +34,7 @@ final class Entries
             ],
             'map_meta_cap'     => true,
             'menu_icon'        => 'dashicons-clipboard',
+            'menu_position'    => 57,
             'show_ui'          => true,
             'supports'         => array('title'),
         ]);


### PR DESCRIPTION
When you have a website with multiple Post types the "Entries" posttype ends up somewhere between the posttypes because the argument `menu_position` is not set. 

This PR sets the "Entries" menu item to position 57, which is just above "Media".